### PR TITLE
Fix compilation on linux/gcc 5.3.

### DIFF
--- a/examples/1bitsy/zork/cdcacm.c
+++ b/examples/1bitsy/zork/cdcacm.c
@@ -19,7 +19,7 @@
 
 #include "cdcacm.h"
 #include "systick.h"
-#include "LED-ping.h"
+#include "led-ping.h"
 
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>

--- a/examples/1bitsy/zork/tty-stdio.c
+++ b/examples/1bitsy/zork/tty-stdio.c
@@ -1,5 +1,6 @@
 #include "tty-stdio.h"
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Linux cares about the case of filenames unlike OS X.

We need to define _GNU_SOURCE so that the cookie_io_functions_t struct is defined.
